### PR TITLE
fix: PY column scale bug

### DIFF
--- a/package/src/chart/Scale.js
+++ b/package/src/chart/Scale.js
@@ -16,7 +16,7 @@ export class Scale {
       const dataPoint = data[i];
       const { left, primary, right } = DataPoint.allValues(dataPoint);
 
-      [(left, right)].forEach((metaDataPoints) => {
+      [left, right].forEach((metaDataPoints) => {
         let positiveStackedHeight = 0;
         let negativeStackedHeight = 0;
 


### PR DESCRIPTION
PY is not scaled correctly due to an unwanted tuple in the code. 